### PR TITLE
Remove missing social link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,8 +31,6 @@ footer:
 social:
   - title: twitter
     url: http://twitter.com/tygamesbzh
-  - title: facebook
-    url:
   - title: github
     url: http://github.com/tygamesbzh
 


### PR DESCRIPTION
On your socials links (footer), Facebook is present but without the link.
I tried do find your page on Facebook but with no luck, maybe you can just remove the link.

